### PR TITLE
riscv: fix a typo in assigning FFI_DEFAULT_ABI for rv32 double float abi

### DIFF
--- a/src/riscv/ffitarget.h
+++ b/src/riscv/ffitarget.h
@@ -77,7 +77,7 @@ typedef enum ffi_abi {
    #elif __riscv_float_abi_single
     FFI_DEFAULT_ABI = FFI_RV32_SINGLE
    #else
-    FFI_DEFAULT_ABI - FFI_RV32_DOUBLE
+    FFI_DEFAULT_ABI = FFI_RV32_DOUBLE
 //  #else
 //    FFI_DEFAULT_ABI = FFI_RV32
   #endif


### PR DESCRIPTION
Instead of assigning FFI_RV32_DOUBLE to FFI_DEFAULT_ABI, the current
code subtracts it. Fix it by s/-/=/.